### PR TITLE
Portuguese word incorrectly spelled

### DIFF
--- a/pt/index.html
+++ b/pt/index.html
@@ -563,7 +563,7 @@
                     <blockquote>
                         <p>Ultimamente eu me econtro bastante dependente de listas do Twitter e círculos do G+ para ficar atualizado com o que está acontecendo no front-end.</p>
 
-                        <p>Se existem ferramentas ou bibliotecas que uso regularmente, tento ficar de olho no que os desenvolvedores que estão trabalhando nela tem a dizer, porque é assim que você consegue descobrir dicas/truques e informaçṍes sobre o que está por vir.</p>
+                        <p>Se existem ferramentas ou bibliotecas que uso regularmente, tento ficar de olho no que os desenvolvedores que estão trabalhando nela tem a dizer, porque é assim que você consegue descobrir dicas/truques e informações sobre o que está por vir.</p>
 
                         <p>Também é uma ótima idéia acompanhar as almas gentis que estão trabalhando em nosso nome no universo de padrões web. Mais frequentemente nos dias de hoje, rascunhos de possíveis especificações são postadas em redes sociais, onde você consegue ter a oportunidade de fazer uma crítica, ou se tiver interessado, contribuir para a o que a plataforma web possa parecer daqui há alguns anos.</p>
 


### PR DESCRIPTION
The word information is written incorrectly (informaçṍes), is the correct (informações).
