### PR TITLE
Updated URL to .Net magazine website

### DIFF
--- a/data/blogs.json
+++ b/data/blogs.json
@@ -53,7 +53,7 @@
 
     {
         "name": ".net Magazine",
-        "permalink": "http://www.netmagazine.com/",
+        "permalink": "http://www.creativebloq.com/net-magazine/",
         "img": "http://twitter.com/api/users/profile_image/netmag?size=bigger",
         "description": {
             "en": ".net is the world’s best-selling magazine for web designers and developers.",


### PR DESCRIPTION
Description probably needs to change as .Net website is now called/branded Creative Bloq
